### PR TITLE
Fature/rebranding and signin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ yarn-debug.log*
 .idea/misc.xml
 *.xml
 .generators
-.idea/pmp-idam.iml
+.idea/tailspend-idam.iml
 .vscode/settings.json
 *.crt
 local-ssl-cert/localhost.key

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ deploy:
   deployment_strategy: rolling
   space: $SPACE_NAME
   on:
-    repo: Crown-Commercial-Service/pmp-idam
+    repo: Crown-Commercial-Service/tailspend-idam
     all_branches: true
     condition: $DEPLOY_BRANCH = TRUE
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ addons:
 before_script:
   - sudo apt-get -qq update
   - sudo apt-get install -y postgresql-11-postgis-2.5
-  - psql -U postgres -c 'create database pmp_idam_test'
-  - psql -U postgres -d pmp_idam_test -c 'create extension postgis'
+  - psql -U postgres -c 'create database tailspend_idam_test'
+  - psql -U postgres -d tailspend_idam_test -c 'create extension postgis'
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ This project uses environment variables which you will need to add to your .env.
 - **AWS_ACCESS_KEY** - The access key for the AWS environment
 - **AWS_SECRET_KEY** - The secret key for the AWS environment
 - **AUTH_USER_API_TOKEN** - The token for the authentication of a user when signing in
-- **PRINT_MARKET_PLACE_KEYCLOAK_URL** - `http://localhost:8080`
+- **OFFICE_TEAM_GET_URL** - `http://localhost:8080`
+- **MERCATEO_GET_URL** - `http://localhost:8080`
 
 ## Running the application
 To run the application use:
@@ -90,7 +91,11 @@ This application is an interim IDAM solution to allow users to log into the Tail
 
 To download and run the container, use the following command:
 ```
-docker run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin quay.io/keycloak/keycloak:11.0.2
+docker run --rm -p 8080:8080 \
+  -e KEYCLOAK_USER=admin \
+  -e KEYCLOAK_PASSWORD=admin \
+  -e DB_VENDOR=h2 \
+  quay.io/keycloak/keycloak:11.0.2
 ```
 This will get the Keycloak container running on localhost port 8080.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Print Marketplace IDAM
+# Tail Spend Solution IDAM
 
 [![Build Status](https://app.travis-ci.com/Crown-Commercial-Service/pmp-idam.svg?branch=develop)](https://app.travis-ci.com/Crown-Commercial-Service/pmp-idam)
 [![Maintainability](https://api.codeclimate.com/v1/badges/0cd357c324b2731fb1bc/maintainability)](https://codeclimate.com/github/Crown-Commercial-Service/pmp-idam/maintainability)
@@ -86,7 +86,7 @@ This will then run the rails server on localhost:3000 but you will need to do so
 
 ## Using the application in the development environment
 ### Running Keycloak in the Docker container
-This application is an interim IDAM solution to allow users to log into the Print Marketplace service. This service is being hosted and maintained externally but it is using an application called Keycloak for its single-sign-on. Therefore you will need to run a local version of the application in a Docker container for development purposes. You may find this [document](https://www.keycloak.org/getting-started/getting-started-docker) helpful if this README is not sufficient.
+This application is an interim IDAM solution to allow users to log into the Tail Spend Solution service. This service is being hosted and maintained externally but it is using an application called Keycloak for its single-sign-on. Therefore you will need to run a local version of the application in a Docker container for development purposes. You may find this [document](https://www.keycloak.org/getting-started/getting-started-docker) helpful if this README is not sufficient.
 
 To download and run the container, use the following command:
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tail Spend Solution IDAM
 
-[![Build Status](https://app.travis-ci.com/Crown-Commercial-Service/pmp-idam.svg?branch=develop)](https://app.travis-ci.com/Crown-Commercial-Service/pmp-idam)
-[![Maintainability](https://api.codeclimate.com/v1/badges/0cd357c324b2731fb1bc/maintainability)](https://codeclimate.com/github/Crown-Commercial-Service/pmp-idam/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/0cd357c324b2731fb1bc/test_coverage)](https://codeclimate.com/github/Crown-Commercial-Service/pmp-idam/test_coverage)
+[![Build Status](https://app.travis-ci.com/Crown-Commercial-Service/pmp-idam.svg?branch=develop)](https://app.travis-ci.com/Crown-Commercial-Service/tailspend-idam)
+[![Maintainability](https://api.codeclimate.com/v1/badges/0cd357c324b2731fb1bc/maintainability)](https://codeclimate.com/github/Crown-Commercial-Service/tailspend-idam/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/0cd357c324b2731fb1bc/test_coverage)](https://codeclimate.com/github/Crown-Commercial-Service/tailspend-idam/test_coverage)
 
 ## Prerequisites
 

--- a/app/controllers/base/sessions_controller.rb
+++ b/app/controllers/base/sessions_controller.rb
@@ -76,6 +76,7 @@ module Base
       @client_call.expires_in = cognito_response.expires_in
       @client_call.sub = decoded_token[0]['sub']
       @client_call.nonce = client_nonce
+      @client_call.id = SecureRandom.uuid
       @client_call.save!
       get_saved_client(id_token)
     end

--- a/app/controllers/base/sessions_controller.rb
+++ b/app/controllers/base/sessions_controller.rb
@@ -76,7 +76,6 @@ module Base
       @client_call.expires_in = cognito_response.expires_in
       @client_call.sub = decoded_token[0]['sub']
       @client_call.nonce = client_nonce
-      @client_call.id = SecureRandom.uuid
       @client_call.save!
       get_saved_client(id_token)
     end

--- a/app/javascript/packs/autocomplete.js
+++ b/app/javascript/packs/autocomplete.js
@@ -2,7 +2,7 @@ import accessibleAutocomplete from 'accessible-autocomplete';
 
 let noResults = false;
 
-const pmpAutoComplete = {
+const tailspendAutoComplete = {
   autocomplete: [],
 
   query(query, populateResults) {
@@ -23,10 +23,10 @@ const pmpAutoComplete = {
   },
 
   initAutoComplete() {
-    pmpAutoComplete.autocomplete = accessibleAutocomplete({
+    tailspendAutoComplete.autocomplete = accessibleAutocomplete({
       element: document.querySelector('#my-autocomplete-container'),
       id: 'cognito_sign_up_user_organisation',
-      source: pmpAutoComplete.query,
+      source: tailspendAutoComplete.query,
       name: 'cognito_sign_up_user[organisation_name]',
       minLength: 3,
       defaultValue: $('#cognito_sign_up_user_summary_line').val(),
@@ -58,6 +58,6 @@ const pmpAutoComplete = {
 
 $(() => {
   if ($('#my-autocomplete-container').length > 0) {
-    pmpAutoComplete.initAutoComplete();
+    tailspendAutoComplete.initAutoComplete();
   }
 });

--- a/app/javascript/packs/cookie-policy.js
+++ b/app/javascript/packs/cookie-policy.js
@@ -14,27 +14,27 @@ const removeGACookies = () => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
-  if (Cookies.get('pmp_cookie_settings_viewed') === 'true') $('#cookie-consent-container').hide();
-  if (Cookies.get('pmp_google_analytics_enabled') !== 'true') removeGACookies();
+  if (Cookies.get('tailspend_cookie_settings_viewed') === 'true') $('#cookie-consent-container').hide();
+  if (Cookies.get('tailspend_google_analytics_enabled') !== 'true') removeGACookies();
 });
 
 $(() => {
   $('#accept-all-cookies').on('click', (e) => {
     e.preventDefault();
 
-    Cookies.set('pmp_cookie_settings_viewed', 'true', { expires: 365 });
-    Cookies.set('pmp_google_analytics_enabled', 'true', { expires: 365 });
+    Cookies.set('tailspend_cookie_settings_viewed', 'true', { expires: 365 });
+    Cookies.set('tailspend_google_analytics_enabled', 'true', { expires: 365 });
     $('#cookie-options-container').hide();
     $('#cookies-accepted-container').show();
   });
 
   $('#save-cookie-settings-button').on('click', () => {
-    Cookies.set('pmp_cookie_settings_viewed', 'true', { expires: 365 });
+    Cookies.set('tailspend_cookie_settings_viewed', 'true', { expires: 365 });
 
     if ($('input[name=ga_cookie_usage]:checked').val() === 'true') {
-      Cookies.set('pmp_google_analytics_enabled', 'true', { expires: 365 });
+      Cookies.set('tailspend_google_analytics_enabled', 'true', { expires: 365 });
     } else {
-      Cookies.remove('pmp_google_analytics_enabled');
+      Cookies.remove('tailspend_google_analytics_enabled');
       removeGACookies();
     }
 

--- a/app/javascript/packs/stylesheets/govuk.scss
+++ b/app/javascript/packs/stylesheets/govuk.scss
@@ -98,7 +98,7 @@ abbr[title] {
     text-decoration: none;
 }
 
-.pmp-logo svg {
+.tailspend-logo svg {
   width: 150px;
   height: 150px;
 }

--- a/app/services/cognito/confirm_password_reset.rb
+++ b/app/services/cognito/confirm_password_reset.rb
@@ -18,10 +18,7 @@ module Cognito
     end
 
     def call
-      if valid?
-        create_user_if_needed
-        confirm_forgot_password
-      end
+      confirm_forgot_password if valid?
     rescue Aws::CognitoIdentityProvider::Errors::CodeMismatchException => e
       errors.add(:confirmation_code, e.message)
     rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
@@ -42,15 +39,6 @@ module Cognito
         password: password,
         confirmation_code: confirmation_code
       )
-    end
-
-    def create_user_if_needed
-      resp = CreateUserFromCognito.call(email)
-      if resp.success?
-        resp.user
-      else
-        errors.add(:base, I18n.t('activemodel.errors.models.cognito/confirm_password_reset.user_not_found'))
-      end
     end
   end
 end

--- a/app/services/cognito/sign_in_user.rb
+++ b/app/services/cognito/sign_in_user.rb
@@ -51,8 +51,8 @@ module Cognito
     def initiate_auth
       cognito_common = Cognito::Common.new
       client_creds = cognito_common.get_client_credentials(client_id)
-
-      if client_creds.user_pool_client.explicit_auth_flows.include? 'USER_PASSWORD_AUTH'
+      if (client_creds.user_pool_client.explicit_auth_flows & %w[USER_PASSWORD_AUTH ALLOW_USER_PASSWORD_AUTH]).any?
+        byebug
         login_user_cognito(client_creds.user_pool_client.client_id, client_creds.user_pool_client.client_secret)
       else
         @error = I18n.t('base.users.sign_in_error')

--- a/app/services/cognito/sign_in_user.rb
+++ b/app/services/cognito/sign_in_user.rb
@@ -51,8 +51,7 @@ module Cognito
     def initiate_auth
       cognito_common = Cognito::Common.new
       client_creds = cognito_common.get_client_credentials(client_id)
-
-      if client_creds.user_pool_client.explicit_auth_flows.include? 'USER_PASSWORD_AUTH'
+      if (client_creds.user_pool_client.explicit_auth_flows & %w[USER_PASSWORD_AUTH ALLOW_USER_PASSWORD_AUTH]).any?
         login_user_cognito(client_creds.user_pool_client.client_id, client_creds.user_pool_client.client_secret)
       else
         @error = I18n.t('base.users.sign_in_error')

--- a/app/services/cognito/sign_in_user.rb
+++ b/app/services/cognito/sign_in_user.rb
@@ -52,7 +52,6 @@ module Cognito
       cognito_common = Cognito::Common.new
       client_creds = cognito_common.get_client_credentials(client_id)
       if (client_creds.user_pool_client.explicit_auth_flows & %w[USER_PASSWORD_AUTH ALLOW_USER_PASSWORD_AUTH]).any?
-        byebug
         login_user_cognito(client_creds.user_pool_client.client_id, client_creds.user_pool_client.client_secret)
       else
         @error = I18n.t('base.users.sign_in_error')

--- a/app/services/cognito/sign_in_user.rb
+++ b/app/services/cognito/sign_in_user.rb
@@ -51,7 +51,8 @@ module Cognito
     def initiate_auth
       cognito_common = Cognito::Common.new
       client_creds = cognito_common.get_client_credentials(client_id)
-      if (client_creds.user_pool_client.explicit_auth_flows & %w[USER_PASSWORD_AUTH ALLOW_USER_PASSWORD_AUTH]).any?
+
+      if client_creds.user_pool_client.explicit_auth_flows.include? 'USER_PASSWORD_AUTH'
         login_user_cognito(client_creds.user_pool_client.client_id, client_creds.user_pool_client.client_secret)
       else
         @error = I18n.t('base.users.sign_in_error')

--- a/app/services/cognito/sign_up_user.rb
+++ b/app/services/cognito/sign_up_user.rb
@@ -3,7 +3,11 @@
 module Cognito
   class SignUpUser < BaseService
     include ActiveModel::Validations
+<<<<<<< HEAD
     validates_presence_of :email, :first_name, :last_name, :summary_line
+=======
+    validates_presence_of :email, :first_name, :last_name, :organisation
+>>>>>>> e04eda5 (Added organisation back in, also set up manifest.yml for dev deployment)
 
     validates :first_name,
               length: { minimum: 2 }
@@ -13,8 +17,12 @@ module Cognito
     include PasswordValidator
 
     validate :domain_in_allow_list, unless: -> { errors[:email].any? }
+<<<<<<< HEAD
     validate :organisation_present
     attr_reader :email, :first_name, :last_name, :summary_line, :password, :password_confirmation, :organisation
+=======
+    attr_reader :email, :first_name, :last_name, :organisation, :password, :password_confirmation
+>>>>>>> e04eda5 (Added organisation back in, also set up manifest.yml for dev deployment)
     attr_accessor :user, :not_on_allow_list
 
     def initialize(params = {})
@@ -22,8 +30,12 @@ module Cognito
       @email = params[:email].try(:downcase)
       @password = params[:password]
       @password_confirmation = params[:password_confirmation]
+<<<<<<< HEAD
       @summary_line = params[:summary_line]
       @organisation = Organisation.find_organisation(@summary_line)
+=======
+      @organisation = params[:organisation]
+>>>>>>> e04eda5 (Added organisation back in, also set up manifest.yml for dev deployment)
       @first_name = params[:first_name]
       @last_name = params[:last_name]
       @not_on_allow_list = nil
@@ -65,7 +77,11 @@ module Cognito
           },
           {
             name: 'custom:organisation_name',
+<<<<<<< HEAD
             value: organisation.organisation_name
+=======
+            value: organisation
+>>>>>>> e04eda5 (Added organisation back in, also set up manifest.yml for dev deployment)
           },
           # Some user do not have phone number so we add adummy number
           # just so cognito can have a number cognito limitaions.

--- a/app/services/cognito/sign_up_user.rb
+++ b/app/services/cognito/sign_up_user.rb
@@ -3,11 +3,7 @@
 module Cognito
   class SignUpUser < BaseService
     include ActiveModel::Validations
-<<<<<<< HEAD
     validates_presence_of :email, :first_name, :last_name, :summary_line
-=======
-    validates_presence_of :email, :first_name, :last_name, :organisation
->>>>>>> e04eda5 (Added organisation back in, also set up manifest.yml for dev deployment)
 
     validates :first_name,
               length: { minimum: 2 }
@@ -17,12 +13,8 @@ module Cognito
     include PasswordValidator
 
     validate :domain_in_allow_list, unless: -> { errors[:email].any? }
-<<<<<<< HEAD
     validate :organisation_present
     attr_reader :email, :first_name, :last_name, :summary_line, :password, :password_confirmation, :organisation
-=======
-    attr_reader :email, :first_name, :last_name, :organisation, :password, :password_confirmation
->>>>>>> e04eda5 (Added organisation back in, also set up manifest.yml for dev deployment)
     attr_accessor :user, :not_on_allow_list
 
     def initialize(params = {})
@@ -30,12 +22,8 @@ module Cognito
       @email = params[:email].try(:downcase)
       @password = params[:password]
       @password_confirmation = params[:password_confirmation]
-<<<<<<< HEAD
       @summary_line = params[:summary_line]
       @organisation = Organisation.find_organisation(@summary_line)
-=======
-      @organisation = params[:organisation]
->>>>>>> e04eda5 (Added organisation back in, also set up manifest.yml for dev deployment)
       @first_name = params[:first_name]
       @last_name = params[:last_name]
       @not_on_allow_list = nil
@@ -77,11 +65,7 @@ module Cognito
           },
           {
             name: 'custom:organisation_name',
-<<<<<<< HEAD
             value: organisation.organisation_name
-=======
-            value: organisation
->>>>>>> e04eda5 (Added organisation back in, also set up manifest.yml for dev deployment)
           },
           # Some user do not have phone number so we add adummy number
           # just so cognito can have a number cognito limitaions.

--- a/app/views/home/accessibility_statement.html.erb
+++ b/app/views/home/accessibility_statement.html.erb
@@ -136,7 +136,7 @@
     </h2>
     <div>
       <h3 class='govuk-heading-s'>
-        <%= t('.core_pmp') %>
+        <%= t('.core_tailspend') %>
       </h3>
       <p>
         <%= t('.several_aspects') %>

--- a/app/views/home/cookie_settings.html.erb
+++ b/app/views/home/cookie_settings.html.erb
@@ -65,11 +65,11 @@
 
       <div class="govuk-radios">
         <div class="govuk-radios__item">
-          <%= radio_button_tag :ga_cookie_usage, true, cookies[:pmp_google_analytics_enabled] == 'true', class: 'govuk-radios__input' %>
+          <%= radio_button_tag :ga_cookie_usage, true, cookies[:tailspend_google_analytics_enabled] == 'true', class: 'govuk-radios__input' %>
           <%= label_tag :ga_cookie_usage, t('.use_cookies'), for: :ga_cookie_usage_true, class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag :ga_cookie_usage, false, cookies[:pmp_google_analytics_enabled] != 'true', class: 'govuk-radios__input' %>
+          <%= radio_button_tag :ga_cookie_usage, false, cookies[:tailspend_google_analytics_enabled] != 'true', class: 'govuk-radios__input' %>
           <%= label_tag :ga_cookie_usage, t('.dont_use_cookies'), for: :ga_cookie_usage_false, class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,6 +12,7 @@
     <p>
       <%= t('.subheading') %>
     </p>
+    <p><%= t('.subheading2') %></p>
     <p>
       <%= t('.no_account_html', registration_link: link_to(t('.register_for_one_here'), base_new_user_registration_path, class: 'govuk-link govuk-link--no-visited-state')) %>
     </p>
@@ -26,6 +27,7 @@
     <p class="govuk-body">
       <%= t('.to_use_this_service_html', authorised_customer_list: link_to(t('.authorised_customer_list'), t('.authorised_customer_list_link'), title: t('.authorised_customer_list_title'), class: 'govuk-link govuk-link--no-visited-state')) %>    
     </p>
-    <%= link_to t('.sign_in'), ENV['PRINT_MARKET_PLACE_KEYCLOAK_URL'], title: t('.sign_in_title'), class: 'govuk-button'%>
+    <%= link_to t('.sign_in_office_team'), ENV['PRINT_MARKET_PLACE_KEYCLOAK_URL'], title: t('.sign_in_title_office_team'), class: 'govuk-button'%>
+    <%= link_to t('.sign_in_mercateo'), ENV['PRINT_MARKET_PLACE_KEYCLOAK_URL'], title: t('.sign_in_title_mercateo'), class: 'govuk-button'%>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -27,7 +27,7 @@
     <p class="govuk-body">
       <%= t('.to_use_this_service_html', authorised_customer_list: link_to(t('.authorised_customer_list'), t('.authorised_customer_list_link'), title: t('.authorised_customer_list_title'), class: 'govuk-link govuk-link--no-visited-state')) %>    
     </p>
-    <%= link_to t('.sign_in_office_team'), ENV['PRINT_MARKET_PLACE_KEYCLOAK_URL'], title: t('.sign_in_title_office_team'), class: 'govuk-button'%>
-    <%= link_to t('.sign_in_mercateo'), ENV['PRINT_MARKET_PLACE_KEYCLOAK_URL'], title: t('.sign_in_title_mercateo'), class: 'govuk-button'%>
+    <%= link_to t('.sign_in_office_team'), ENV['OFFICE_TEAM_GET_URL'], title: t('.sign_in_title_office_team'), class: 'govuk-button'%>
+    <%= link_to t('.sign_in_mercateo'), ENV['MERCATEO_GET_URL'], title: t('.sign_in_title_mercateo'), class: 'govuk-button'%>
   </div>
 </div>

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,10 +1,10 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=<%= PmpIdam.google_analytics_id %>">
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= TailspendIdam.google_analytics_id %>">
 </script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '<%= PmpIdam.google_analytics_id %>');
+  gtag('config', '<%= TailspendIdam.google_analytics_id %>');
 </script>

--- a/app/views/layouts/_header-banner.html.erb
+++ b/app/views/layouts/_header-banner.html.erb
@@ -1,6 +1,6 @@
 <%= render 'layouts/logo' %>
 <div class="govuk-header__content">
-  <span class="govuk-header__link--service-name">Sign in to the Print Marketplace</span>
+  <span class="govuk-header__link--service-name">Sign in to the Tail Spend Solution</span>
   <% unless current_page?('/')  %>
     <nav role="navigation" aria-label="Top Level Navigation">
       <ul id="navigation" class="govuk-header__navigation ">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
 
   <meta property="og:image" content="<%= asset_pack_url('media/images/govuk-opengraph-image.png') %>">
 
-  <%= render partial: '/layouts/google_analytics' if cookies[:pmp_google_analytics_enabled] == 'true' && PmpIdam.google_analytics_id.present? %>
+  <%= render partial: '/layouts/google_analytics' if cookies[:tailspend_google_analytics_enabled] == 'true' && PmpIdam.google_analytics_id.present? %>
   <%= canonical_tag %>
 </head>
 
@@ -37,7 +37,7 @@
   <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
   <header id="main-header" class="govuk-header" role="banner" data-module="header">
-    <%= render partial: '/layouts/cookie-banner' unless cookies[:pmp_cookie_settings_viewed] == 'true' || request.path == '/cookie-settings' %>
+    <%= render partial: '/layouts/cookie-banner' unless cookies[:tailspend_cookie_settings_viewed] == 'true' || request.path == '/cookie-settings' %>
     <div class="govuk-header__container govuk-width-container">
       <%= render partial: '/layouts/header-banner', locals: {end_of_journey: false} %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
 
   <meta property="og:image" content="<%= asset_pack_url('media/images/govuk-opengraph-image.png') %>">
 
-  <%= render partial: '/layouts/google_analytics' if cookies[:tailspend_google_analytics_enabled] == 'true' && PmpIdam.google_analytics_id.present? %>
+  <%= render partial: '/layouts/google_analytics' if cookies[:tailspend_google_analytics_enabled] == 'true' && TailspendIdam.google_analytics_id.present? %>
   <%= canonical_tag %>
 </head>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ require 'rails/test_unit/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module PmpIdam
+module TailspendIdam
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0

--- a/config/database.yml
+++ b/config/database.yml
@@ -25,7 +25,7 @@ default: &default
 
 development:
   <<: *default
-  database: pmp_idam_development
+  database: tailspend_idam_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -59,7 +59,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: pmp_idam_test
+  database: tailspend_idam_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "pmp_idam_production"
+  # config.active_job.queue_name_prefix = "tailspend_idam_production"
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -7,7 +7,7 @@ CanonicalRails.setup do |config|
 
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
-  config.host = 'printmarketplace.crowncommercial.gov.uk'
+  config.host = 'tailspend.crowncommercial.gov.uk'
   config.port = '443'
 
   # http://en.wikipedia.org/wiki/URL_normalization

--- a/config/initializers/cf_vault.rb
+++ b/config/initializers/cf_vault.rb
@@ -23,4 +23,4 @@ def set_env(storage_path)
 end
 # rubocop:enable Naming/AccessorMethodName
 
-config_vault if ENV['SERVER_ENV_NAME'].present?
+# config_vault if ENV['SERVER_ENV_NAME'].present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -226,7 +226,7 @@ en:
       autocomplete_heading: Autocomplete is not enabled for user sign in fields
       autocomplete_issue: A user must manually input their first name, last name and email address when registering to use the service for the first time. This is in place to ensure no erroneous or malicious registration can take place.
       call: call 0345 410 2222
-      core_pmp: Core Tail Spend Solution product
+      core_tailspend: Core Tail Spend Solution product
       email: email
       email_link: info@crowncommercial.gov.uk
       equality: The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint,
@@ -270,11 +270,11 @@ en:
       change_your_settings: Change your settings
       cookie_message_1:
         expires: 1 year
-        name: pmp_google_analytics_enabled
+        name: tailspend_google_analytics_enabled
         purpose: Saves your cookie consent settings for Google Analytics
       cookie_message_2:
         expires: 1 year
-        name: pmp_cookie_settings_viewed
+        name: tailspend_cookie_settings_viewed
         purpose: Lets us know that you’ve viewed your cookie consent settings
       cookies_message: Cookies message
       ga_cookies_1:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,7 +250,7 @@ en:
       list_1_navigate_speach: navigate most of the website using speech recognition software
       list_2_decorative: non-decorative content is used in the CCS sign-in pages, which may make it in accessible to users navigating the site with screen readers.
       list_2_email: the email field on the homepage lacks an autocomplete attribute, so its purpose cannot be determined programmatically
-      market_place_link: https://printmarketplace.crowncommercial.gov.uk/
+      market_place_link: https://tailspend.crowncommercial.gov.uk/
       several_aspects: Several aspects of the Tail Spend Solution user journey do not meet the WCAG 2.1 AA success criteria. The accessibility statement on the core Tail Spend Solution product details these.
       the_complete_journey: The complete Tail Spend Solution journey was tested, this included every page a buyer would progress through in-order to complete the sign up activity.
       the_content: The content listed below is non-accessible for the following reasons.
@@ -343,7 +343,7 @@ en:
       cookies_acepted_html: You’ve accepted all cookies. You can %{cookies_acepted_link} at any time.
       cookies_acepted_link_text: change your cookie settings
       set_cookie_preferences: Set cookie preferences
-      why_we_use_cookies: We use cookies to collect information about how you use printmarketplace.crowncommercial.gov.uk. We use this information to make the website work as well as possible and improve government services.
+      why_we_use_cookies: We use cookies to collect information about how you use tailspend.crowncommercial.gov.uk. We use this information to make the website work as well as possible and improve government services.
     footer:
       accessibility_statement_link: Accessibility statement
       accessibility_statement_link_aria_label: View our accessibility statement

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -328,10 +328,10 @@ en:
       heading: Tail Spend Solution
       no_account_html: Not got an account? You can %{registration_link}.
       register_for_one_here: register for one here
-      sign_in_office_team: Sign in to Office Team
       sign_in_mercateo: Sign in to Mercateo
-      sign_in_title_office_team: Login to Office Team
+      sign_in_office_team: Sign in to Office Team
       sign_in_title_mercateo: Login to Mercateo
+      sign_in_title_office_team: Login to Office Team
       subheading: The Tail Spend Solution will provide customers the choice of two digital solutions to browse a broad product range classified as 'Tail spend'. Tail spend is described as ad-hoc low volume and usually low value.
       subheading2: Please note a Framework call off needs to have been conducted by the customer organisation prior to registration.
       to_use_this_service_html: To use this service you need to be a recognised public sector body listed in the %{authorised_customer_list}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,7 +148,7 @@ en:
         verify_code: Verification code
       new:
         email: Email address
-        email_hint_html: This is the email address you used to set up the Print Marketplace account.
+        email_hint_html: This is the email address you used to set up the Tail Spend Solution account.
         heading: Reset password
         lead: Enter your email address and we’ll send you a verification code so you can reset your password. Password reset verification codes are only valid for 24 hours.
       password_reset_success:
@@ -170,7 +170,7 @@ en:
         email_hint: We will send a confirmation code to this address.
         first_name: First name
         first_name_hint: Add your first name here.
-        heading_html: Create a Print Marketplace buyer account
+        heading_html: Create a Tail Spend Solution account
         last_name: Last name
         last_name_hint: Add your last name here.
         lead: You must be employed by, or represent, a public sector organisation.
@@ -226,13 +226,13 @@ en:
       autocomplete_heading: Autocomplete is not enabled for user sign in fields
       autocomplete_issue: A user must manually input their first name, last name and email address when registering to use the service for the first time. This is in place to ensure no erroneous or malicious registration can take place.
       call: call 0345 410 2222
-      core_pmp: Core Print Marketplace product
+      core_pmp: Core Tail Spend Solution product
       email: email
       email_link: info@crowncommercial.gov.uk
       equality: The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint,
       equality_link: https://www.equalityadvisoryservice.com/
       equality_link_text: contact the Equality Advisory and Support Service (EASS)
-      heading: Print Marketplace (PMP) Accessibility statement
+      heading: Tail Spend Solution (TSS) Accessibility statement
       heading_content_not_in_scope: Content that’s not within the scope of the accessibility regulations
       heading_enforcement: Enforcement procedure
       heading_how_accessible: How accessible this website is
@@ -251,10 +251,10 @@ en:
       list_2_decorative: non-decorative content is used in the CCS sign-in pages, which may make it in accessible to users navigating the site with screen readers.
       list_2_email: the email field on the homepage lacks an autocomplete attribute, so its purpose cannot be determined programmatically
       market_place_link: https://printmarketplace.crowncommercial.gov.uk/
-      several_aspects: Several aspects of the print marketplace user journey do not meet the WCAG 2.1 AA success criteria. The accessibility statement on the core Print Marketplace product details these.
-      the_complete_journey: The complete Print Marketplace journey was tested, this included every page a buyer would progress through in-order to complete the sign up activity.
+      several_aspects: Several aspects of the Tail Spend Solution user journey do not meet the WCAG 2.1 AA success criteria. The accessibility statement on the core Tail Spend Solution product details these.
+      the_complete_journey: The complete Tail Spend Solution journey was tested, this included every page a buyer would progress through in-order to complete the sign up activity.
       the_content: The content listed below is non-accessible for the following reasons.
-      this_statement: 'This accessibility statement applies to the sign in pages of the Print Marketplace digital service which can be found at the following URL:'
+      this_statement: 'This accessibility statement applies to the sign in pages of the Tail Spend Solution digital service which can be found at the following URL:'
       this_statement_date: This statement was prepared on 25th November 2020. It will be reviewed and updated as required.
       this_website: 'This website is run by Crown Commercial Service (CCS). We want as many people as possible to be able to use this website. For example, that means you should be able to:'
       this_website_partially_1: This website is partially compliant with the
@@ -290,30 +290,30 @@ en:
         name: _gid
         purpose: This cookie is used to group the user behaviour
       ga_sets_following_cookies: Google Analytics sets the following cookies.
-      heading: Details about cookies on Print Marketplace
+      heading: Details about cookies on Tail Spend Solution
       last_updated: Last updated 26 January 2021
       we_do_not_let: We do not allow Google to use or share the data about how you use this site.
-      what_are_cookies: Print Marketplace puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site. Find out more about the cookies we use, what they’re for and when they expire.
-      you_may_see_a_banner: You may see a banner when you visit Print Marketplace inviting you to accept cookies or review your settings. We’ll set cookies so that your computer knows you’ve seen it and not to show it again, and also to store your settings.
+      what_are_cookies: Tail Spend Solution puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site. Find out more about the cookies we use, what they’re for and when they expire.
+      you_may_see_a_banner: You may see a banner when you visit Tail Spend Solution inviting you to accept cookies or review your settings. We’ll set cookies so that your computer knows you’ve seen it and not to show it again, and also to store your settings.
     cookie_settings:
       always_need_to_be_on: They always need to be on.
       cookie_settings: Cookie settings
       cookies_saved: Your cookie settings were saved
-      cookies_saved_description: Other areas of the Print Marketplace service may set additional cookies and, if so, will have their own cookie policy and banner.
+      cookies_saved_description: Other areas of the Tail Spend Solution service may set additional cookies and, if so, will have their own cookie policy and banner.
       dont_use_cookies: Do not use cookies that measure my website use
       essential_cookies: These essential cookies do things like remember the notifications you have seen so we do not show them to you again.
-      find_out_more: Find out more about cookies on Print Marketplace
-      heading: Cookies on Print Marketplace
+      find_out_more: Find out more about cookies on Tail Spend Solution
+      heading: Cookies on Tail Spend Solution
       save_changes: Save changes
       the_number_we_use: We use 2 types of cookie. You can choose which cookies you're happy for us to use.
       use_cookies: Use cookies that measure my website use
       what_are_cookies: Cookies are files saved on your phone, tablet or computer when you visit a website.
-      why_we_use_them: We use cookies to store information about how you use the Print Marketplace website, such as the pages you visit.
+      why_we_use_them: We use cookies to store information about how you use the Tail Spend Solution website, such as the pages you visit.
     cookies:
       expires: Expires
       ga_list: 'Google Analytics sets cookies that store anonymised information about:'
       ga_list_1: how you got to the site
-      ga_list_2: the pages you visit on Print Marketplace, and how long you spend on each page
+      ga_list_2: the pages you visit on Tail Spend Solution, and how long you spend on each page
       ga_list_3: what you click on while you're visiting the site
       measure_website_use: Cookies that measure website use
       name: Name
@@ -325,12 +325,15 @@ en:
       authorised_customer_list_link: https://assets.crowncommercial.gov.uk/wp-content/uploads/RM3788-Contract-Notice-Authorised-Customer-List.docx
       authorised_customer_list_title: authrized customers list in .docx format
       before_you_start: Before you start
-      heading: Print Marketplace
+      heading: Tail Spend Solution
       no_account_html: Not got an account? You can %{registration_link}.
       register_for_one_here: register for one here
-      sign_in: Sign in to Print Marketplace
-      sign_in_title: Login to print market place
-      subheading: Print Marketplace is a UK-wide digital tool for purchasing printed material, including brochures, flyers, leaflets, business cards, letterheads and other transactional print.
+      sign_in_office_team: Sign in to Office Team
+      sign_in_mercateo: Sign in to Mercateo
+      sign_in_title_office_team: Login to Office Team
+      sign_in_title_mercateo: Login to Mercateo
+      subheading: The Tail Spend Solution will provide customers the choice of two digital solutions to browse a broad product range classified as 'Tail spend'. Tail spend is described as ad-hoc low volume and usually low value.
+      subheading2: Please note a Framework call off needs to have been conducted by the customer organisation prior to registration.
       to_use_this_service_html: To use this service you need to be a recognised public sector body listed in the %{authorised_customer_list}.
   layouts:
     application:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2021_11_25_165513) do
     t.index ["execute_at"], name: "index_arask_jobs_on_execute_at"
   end
 
-  create_table "client_calls", id: :uuid, default: nil, force: :cascade do |t|
+  create_table "client_calls", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "access_token"
     t.string "refresh_token"
     t.string "id_token"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: ccs-pmp-idam-dev
+- name: ccs-tailspend-idam-dev
   memory: 1000M
   buildpacks:
   - nodejs_buildpack
@@ -8,7 +8,6 @@ applications:
   instances: 1
   random-route: true
   services:
-    - ccs-pmp-idam-pg-service-dev
-    - ccs-pmp-idam-dev-s3
+    - ccs-tailspend-idam-dev-pg-service
   env:
     SERVER_ENV_NAME: develop

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pmp_idam",
+  "name": "tailspend_idam",
   "private": true,
   "dependencies": {
     "@rails/ujs": "^6.1.4",

--- a/spec/services/cognito/confirm_password_reset_spec.rb
+++ b/spec/services/cognito/confirm_password_reset_spec.rb
@@ -239,20 +239,9 @@ RSpec.describe Cognito::ConfirmPasswordReset do
           expect(confirm_password_reset.errors[:base].first).to eq 'Some message'
         end
       end
-
-      context 'when the user can not be found' do
-        let(:resp) { instance_double(Cognito::CreateUserFromCognito) }
-
-        before do
-          allow(client).to receive(:confirm_forgot_password)
-          allow(Cognito::CreateUserFromCognito).to receive(:call).with(email).and_return(resp)
-          allow(resp).to receive(:success?).and_return(false)
-          confirm_password_reset.call
-        end
-      end
     end
 
-    context 'when somthing is not valid' do
+    context 'when something is not valid' do
       let(:password_confirmation) { 'Samus' }
 
       before do

--- a/spec/services/cognito/confirm_password_reset_spec.rb
+++ b/spec/services/cognito/confirm_password_reset_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Cognito::ConfirmPasswordReset do
         end
       end
 
-      context 'and it cointains valid symbols' do
+      context 'and it contains valid symbols' do
         let(:password) { ("Password1234#{valid_symbols_sample}").split('').shuffle.join }
 
         it 'is valid' do
@@ -248,10 +248,6 @@ RSpec.describe Cognito::ConfirmPasswordReset do
           allow(Cognito::CreateUserFromCognito).to receive(:call).with(email).and_return(resp)
           allow(resp).to receive(:success?).and_return(false)
           confirm_password_reset.call
-        end
-
-        it 'adds the user can not be found error' do
-          expect(confirm_password_reset.errors[:base].first).to eq 'Please check the information you have entered'
         end
       end
     end


### PR DESCRIPTION
- Rebranding from PMP to Tailspend
- removed redundant create_user_if_needed call
- Added two Sign in buttons for the two suppliers
- Added ALLOW_USER_PASSWORD_AUTH explicit_auth_flows to be checked as newly created client apps do not have the USER_PASSWORD_AUTH auth flow