### PR TITLE
Feature/ts 138 customer list name and Feature/TS-134 header link change

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,4 +39,8 @@ module ApplicationHelper
   def parameters_without_user_details
     request.parameters.except(:cognito_sign_in_user)
   end
+
+  def header_link_text
+    controller.controller_name == 'sessions' && controller.action_name == 'new' ? t('layouts.application.go_back') : t('layouts.application.sign_in')
+  end
 end

--- a/app/views/base/registrations/new.html.erb
+++ b/app/views/base/registrations/new.html.erb
@@ -17,7 +17,7 @@
         <%= t('.bullet1') %>
       </li>
       <li>
-        <%= t('.bullet2_html', authorised_customer_list: link_to(t('home.index.authorised_customer_list'), t('home.index.authorised_customer_list_link'), title: t('home.index.authorised_customer_list_title'), class: 'govuk-link govuk-link--no-visited-state')) %>
+        <%= t('.bullet2_html', authorised_customer_list: link_to(t('home.index.authorised_customer_list'), ENV['CUSTOMER_LIST_URL'], title: t('home.index.authorised_customer_list_title'), class: 'govuk-link govuk-link--no-visited-state')) %>
       </li>
     </ul>
 

--- a/app/views/layouts/_header-banner.html.erb
+++ b/app/views/layouts/_header-banner.html.erb
@@ -5,7 +5,7 @@
     <nav role="navigation" aria-label="Top Level Navigation">
       <ul id="navigation" class="govuk-header__navigation ">
         <li class="govuk-header__navigation-item ">
-          <a class="govuk-header__link" id="back_to_register_link" href="<%= home_path %>"><%= t('layouts.application.sign_in') %></a>
+          <a class="govuk-header__link" id="back_to_register_link" href="<%= home_path %>"><%= header_link_text %></a>
         </li>
       </ul>
     </nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,7 +329,6 @@ en:
       we_use_ga: We use Google Analytics to measure how you use the website so we can improve it based on user needs.
     index:
       authorised_customer_list: authorised customer list
-      authorised_customer_list_link: https://assets.crowncommercial.gov.uk/wp-content/uploads/RM3788-Contract-Notice-Authorised-Customer-List.docx
       authorised_customer_list_title: authrized customers list in .docx format
       create_an_account: create an account
       heading: Sign in to Tail Spend Solution

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,6 +342,7 @@ en:
       subheading4: Your organisation will need to have completed a call-off contract with a supplier before you can create an account.
   layouts:
     application:
+      go_back: Go back
       sign_in: Sign in
       title: Crown Commercial Services
     cookie-banner:


### PR DESCRIPTION
- Moved the customer list link to an env variable so it can be stored onto the Tail Spend S3
- Changed the 'Sign in' header link to 'Go back' only for the sign in page