### PR TITLE
Forcibly block Arask if needed

### DIFF
--- a/config/initializers/arask.rb
+++ b/config/initializers/arask.rb
@@ -1,6 +1,11 @@
-Arask.setup do |arask|
-  arask.create job: 'SalesforceImportJob', cron: '0 */1 * * *', run_first_time: true if Rails.env.production?
+if ENV.fetch('PREVENT_ARASK', '0') != '1'  # Set to '1' to disable Arask job setup
+  Rails.logger.info 'Setting up Arask'
+  Arask.setup do |arask|
+    arask.create job: 'SalesforceImportJob', cron: '0 */1 * * *', run_first_time: true if Rails.env.production?
 
-  # On exceptions, send email with details
-  arask.on_exception email: 'CSI@crowncommercial.gov.uk'
+    # On exceptions, send email with details
+    arask.on_exception email: 'CSI@crowncommercial.gov.uk'
+  end
+else
+  Rails.logger.info 'Skipping Arask setup'
 end


### PR DESCRIPTION
We need to stop Arask from running on ECS web service tasks - it is scalable and we don't want to have concurrent jobs running. Instead we set up a separate ECS one-off service for Tailspend import and therefore we don't want Arask running on the web service. This `if` block delivers that.