### PR TITLE
Block Arask in AWS production + precompile assets for AWS production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN gem install bundler && bundle install --jobs 20 --retry 5
 
 COPY . .
 
+RUN rake assets:precompile
+
 EXPOSE 3000
 
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/config/initializers/arask.rb
+++ b/config/initializers/arask.rb
@@ -1,6 +1,10 @@
-Arask.setup do |arask|
-  arask.create job: 'SalesforceImportJob', cron: '0 */1 * * *', run_first_time: true if Rails.env.production?
+if ENV.fetch('PREVENT_ARASK', '0') == '1'  # Set to '1' to disable Arask job setup
+  Rails.logger.info 'Skipping Arask setup'
+else
+  Rails.logger.info 'Setting up Arask'
+  Arask.setup do |arask|
+    arask.create job: 'SalesforceImportJob', cron: '0 */1 * * *', run_first_time: true if Rails.env.production?
 
-  # On exceptions, send email with details
-  arask.on_exception email: 'CSI@crowncommercial.gov.uk'
+    # On exceptions, send email with details
+    arask.on_exception email: 'CSI@crowncommercial.gov.uk'
 end

--- a/config/initializers/arask.rb
+++ b/config/initializers/arask.rb
@@ -7,4 +7,5 @@ else
 
     # On exceptions, send email with details
     arask.on_exception email: 'CSI@crowncommercial.gov.uk'
+  end
 end


### PR DESCRIPTION
Two small changes rolled into one:

* We need to stop Arask from running on ECS web service tasks - it is scalable and we don't want to have concurrent jobs running. Instead we set up a separate ECS one-off service for Tailspend import and therefore we don't want Arask running on the web service. An `if` block delivers that.
* Production does not run Webpacker on startup for optimisation reasons - Therefore in our prod Docker build we want to run `assets:precompile`