### PR TITLE
Exclude the health check endpoint from the host authorization exclusion

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,4 +86,8 @@ Rails.application.configure do
   ENV.fetch('ALLOWED_HOST_DOMAINS', '').split(',').each do |application_domain|
     config.hosts << application_domain
   end
+
+  config.host_authorization = {
+    exclude: ->(request) { request.path.include?('health_check') }
+  }
 end


### PR DESCRIPTION
This is to help prevent an issue where the app is unable to spin up.