### PR TITLE
Allow the healthcheck endpoint to ignore the SSL config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,6 +37,12 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  config.ssl_options = {
+    redirect: {
+      exclude: ->(request) { request.path.include?('health_check') }
+    }
+  }
+
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)
     .tap  { |logger| logger.formatter = ::Logger::Formatter.new }


### PR DESCRIPTION
This fixes an issue with the deployment where the the app was unable to startup as it could not reach the endpoint