### PR TITLE
Rename `cookie_preferences` cookie to `cookie_preferences_tailspend` so that it does not conflict with corporate website

### DIFF
--- a/app/javascript/packs/cookie-policy.js
+++ b/app/javascript/packs/cookie-policy.js
@@ -14,7 +14,7 @@ const cookieUpdateOptions = [
 const getCookiePreferences = () => {
   const defaultCookieSettings = '{"usage":true,"glassbox":false}'
 
-  return JSON.parse(Cookies.get('cookie_preferences') ?? defaultCookieSettings)
+  return JSON.parse(Cookies.get('cookie_preferences_tailspend') ?? defaultCookieSettings)
 }
 
 const removeUnwantedCookies = () => {

--- a/app/javascript/packs/google-analytics-data-layer.js
+++ b/app/javascript/packs/google-analytics-data-layer.js
@@ -5,12 +5,12 @@ const grantType = {
   notGranted: 'not granted'
 }
 
-const getCookiePreferences = () => Cookies.get('cookie_preferences') ?? '{}'
+const getCookiePreferences = () => Cookies.get('cookie_preferences_tailspend') ?? '{}'
 
-const getCookiePreferencesSaved = () => Cookies.get('cookie_preferences_saved') ?? '{}'
+const getCookiePreferencesSaved = () => Cookies.get('cookie_preferences_tailspend_saved') ?? '{}'
 
 const setCookiePreferencesSaved = (cookiePreferences) => {
-  Cookies.set('cookie_preferences_saved', JSON.stringify(cookiePreferences), { expires: 365 })
+  Cookies.set('cookie_preferences_tailspend_saved', JSON.stringify(cookiePreferences), { expires: 365 })
 }
 
 const getGrantedText = (state) => state ? grantType.granted : grantType.notGranted

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,7 +71,7 @@ module TailspendIdam
   end
 
   def self.cookie_settings_name
-    :cookie_preferences
+    :cookie_preferences_tailspend
   end
 
   def self.default_cookie_options

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,7 +287,7 @@ en:
           purpose: Saves your cookie consent preferences
         row_2:
           expires: 1 year
-          name: cookie_preferences_saved
+          name: cookie_preferences_tailspend_saved
           purpose: Allows us to check when your cookie settings have changed
       cookies_banner: Cookies banner
       ga_cookies:

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_tailspend'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -76,7 +76,7 @@ RSpec.describe HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_tailspend'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -112,7 +112,7 @@ RSpec.describe HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_tailspend'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -140,7 +140,7 @@ RSpec.describe HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_tailspend'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ApplicationHelper do
     end
 
     context 'when the cookie has been set' do
-      before { helper.request.cookies['cookie_preferences'] = cookie_settings }
+      before { helper.request.cookies['cookie_preferences_tailspend'] = cookie_settings }
 
       context 'and it is a hash' do
         let(:expected_cookie_settings) do


### PR DESCRIPTION
Because the cookie_preferences is set by the corporate website which has the .crowncommercial.gov.uk, it will supersede any cookie we set as TailSpend is hosted on a subdomain. Therefore, I have renamed the cookie to remove this conflict.